### PR TITLE
fikset Layout.cshtml; personvern linkes direkte til Kartverket.no

### DIFF
--- a/Views/Home/Privacy.cshtml
+++ b/Views/Home/Privacy.cshtml
@@ -5,40 +5,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title></title>
-    <div class="privacypolicy-h1"
-        <h1>Kartverkets personvernerklæring</h1> 
-    </div>
-
-     <div class="pp-ingress">
-        <h>3Personvernerklæringa forklarer korleis Kartverket behandlar personopplysningar og informasjon om brukarane våre og besøkande på nettsidene våre.</h>
-    </div>
-    <div class="pp-hoveddel"></div>
-    <p>
-        Personopplysningslova gir alle som ber om det, rett til å vite kva ein behandlingsansvarleg gjer med personopplysningar. Behandlingsansvarleg i Kartverket er kartverkssjefen eller den som har fått tildelt fullmakt frå kartverkssjefen. Hos Datatilsynet kan du lese meir om rettane dine.
-
-        Som hovudregel har du rett til å få vite kva som er registrert om deg, og du kan be om utfyllande opplysningar på nokre område:
-
-        Namn og adresse på behandlingsansvarleg
-        Kven som har ansvar dagleg for pliktene som behandlingsansvarleg
-        Kva slags personopplysningar som blir behandla
-        Målet med behandlinga
-        Kor opplysningane er henta
-        Kven personopplysningane eventuelt blir utlevert til
-        Kor lenge opplysningane blir lagra
-        Retten til å krevje endringar eller sletting
-        Retten til å klage til ei tilsynsstyresmakt
-
-        Når du kontaktar oss og ber om informasjon, skal den behandlingsansvarlege svare utan ugrunna opphald. Om du ønsker det, kan du be om å få svaret skriftleg. Den behandlingsansvarlege kan vise til stader der informasjonen allereie er offentleg tilgjengeleg.
-    </p>
-
      </head>
-    
-
     <body>
-        <div class="intro-pp">
-        </div>
-
-
     </body>
 </html>
 

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -22,7 +22,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2024 - Karverket - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+            &copy; 2024 - Karverket - <a href="https://www.kartverket.no/om-kartverket/personvern" target="_blank">Personverns erklæring</a>
         </div>
     </footer>
 


### PR DESCRIPTION
Personverns erklæring linker nå direkte til kartverket.no (ekstern link), stedet for et eget view (Privacy.cshtml).
